### PR TITLE
c# FtpWebRequest calls were failing(returning wrong FTP code)

### DIFF
--- a/AzureFtpServer/Ftp/PasswordCommandHandler.cs
+++ b/AzureFtpServer/Ftp/PasswordCommandHandler.cs
@@ -22,7 +22,7 @@ namespace AzureFtpServer.FtpCommands
             if (ConnectionObject.Login(sMessage))
             {
                 FtpServer.LogWrite(this, "******", 220, 0);
-                return GetMessage(220, "Password ok, FTP server ready");
+                return GetMessage(230, "Password ok, FTP server ready");
             }
             else
             {


### PR DESCRIPTION
Using an example not that dissimilar to `https://docs.microsoft.com/en-us/dotnet/framework/network-programming/how-to-upload-files-with-ftp` it was found that the wrong code was being returned (220) when it should have been 230.

Left unfixed this would cause an exception thrown at the client.
